### PR TITLE
Correlated & uncorrelated TS with exact probability calculation

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -33,7 +33,7 @@ jobs:
         export NUMBA_DISABLE_JIT=1
         pytest --cov=./pyrff --cov-report xml --cov-report term-missing pyrff/
     - name: Upload coverage
-      uses: codecov/codecov-action@v1.0.7
+      uses: codecov/codecov-action@v1
       if: matrix.python-version == 3.8
       with:
         file: ./coverage.xml

--- a/pyrff/__init__.py
+++ b/pyrff/__init__.py
@@ -1,6 +1,6 @@
 from . exceptions import DtypeError, ShapeError
 from . rff import sample_rff, save_rffs, load_rffs
-from . thompson import sample_batch, get_probabilities
+from . thompson import sample_batch, sampling_probabilities
 from . utils import multi_start_fmin
 
-__version__ = '1.0.1'
+__version__ = '2.0.0'

--- a/pyrff/test_thompson.py
+++ b/pyrff/test_thompson.py
@@ -1,6 +1,7 @@
 import numpy
 import pytest
 
+from . import exceptions
 from . import thompson
 
 
@@ -20,6 +21,7 @@ class TestThompsonSampling:
 
         batch = thompson.sample_batch(
             candidate_samples=samples, ids=ids,
+            correlated=False,
             batch_size=batch_size, seed=seed
         )
         assert len(batch) == batch_size
@@ -34,9 +36,54 @@ class TestThompsonSampling:
             [2, 2],
             [2, 2, 2],
         ]
-        batch = thompson.sample_batch(samples, ids=('A', 'B', 'C'), batch_size=100, seed=1234)
+        batch = thompson.sample_batch(samples, ids=('A', 'B', 'C'), correlated=False, batch_size=100, seed=1234)
         assert batch.count('A') != 100
         assert batch.count('C') != 0
+        pass
+
+    def test_correlated_sampling(self):
+        samples = [
+            [1, 2, 3],
+            [1, 1, 1],
+            [0, 1, 2],
+        ]
+        batch = thompson.sample_batch(samples, ids=('A', 'B', 'C'), correlated=True, batch_size=100, seed=1234)
+        assert batch.count('A') < 100
+        assert batch.count('B') < 100 / 3
+        assert batch.count('C') == 0
+        pass
+
+
+class TestExceptions:
+    def test_id_count(self):
+        with pytest.raises(exceptions.ShapeError, match="candidate ids"):
+            thompson.sample_batch([
+                    [1,2,3],
+                    [1,2],
+                ],
+                ids=("A", "B", "C"),
+                correlated=False,
+                batch_size=30,
+            )
+
+    def test_correlated_sample_size_check(self):
+        with pytest.raises(exceptions.ShapeError, match="number of samples"):
+            thompson.sample_batch([
+                    [1,2,3],
+                    [1,2],
+                ],
+                ids=("A", "B"),
+                correlated=True,
+                batch_size=30,
+            )
+
+        with pytest.raises(exceptions.ShapeError):
+            thompson.sampling_probabilities([
+                    [1,2,3],
+                    [1,2],
+                ],
+                correlated=True,
+            )
         pass
 
 
@@ -71,26 +118,39 @@ class TestThompsonProbabilities:
         ])), 0.041666666)
         pass
 
-    def test_sampling_probability(self):
+    def test_sampling_probability_uncorrelated(self):
         numpy.testing.assert_array_equal(thompson.sampling_probabilities([
             [0, 1, 2],
             [0, 1, 2],
-        ]), [0.5, 0.5])
-        
+        ], correlated=False), [0.5, 0.5])
+
         numpy.testing.assert_array_equal(thompson.sampling_probabilities([
             [0, 1, 2],
             [10],
-        ]), [0, 1])
+        ], correlated=False), [0, 1])
 
         numpy.testing.assert_array_equal(thompson.sampling_probabilities([
             [0, 1, 2],
             [3, 4, 5],
             [5, 4, 3],
-        ]), [0, 0.5, 0.5])
+        ], correlated=False), [0, 0.5, 0.5])
 
         numpy.testing.assert_array_equal(thompson.sampling_probabilities([
             [5, 6],
             [0, 0, 10, 20],
             [5, 6],
-        ]), [0.25, 0.5, 0.25])
+        ], correlated=False), [0.25, 0.5, 0.25])
+        pass
+
+    def test_sampling_probability_correlated(self):
+        numpy.testing.assert_array_equal(thompson.sampling_probabilities([
+            [0, 1, 2],
+            [0, 1, 2],
+        ], correlated=True), [0.5, 0.5])
+
+        numpy.testing.assert_array_equal(thompson.sampling_probabilities([
+            [0, 4, 2],
+            [3, 4, 5],
+            [5, 1, 6],
+        ], correlated=True), [0.5/3, 0.5/3, 2/3])
         pass

--- a/pyrff/test_thompson.py
+++ b/pyrff/test_thompson.py
@@ -39,17 +39,3 @@ class TestThompsonSampling:
         assert batch.count('C') != 0
         pass
 
-    @pytest.mark.xfail(reason='Probabilities are currently computed by brute force and non-exact.')
-    def test_get_probabilities_exact_on_identical(self):
-        samples = numpy.array([
-            [1, 2, 3, 4, 5],
-            [5, 3, 4, 2, 1],
-            [1, 3, 4, 2, 5]
-        ]).T
-        S, C = samples.shape
-        assert S == 5
-        assert C == 3
-
-        probabilities = thompson.get_probabilities(samples)
-        numpy.testing.assert_array_equal(probabilities, [1/C]*C)
-        pass

--- a/pyrff/test_thompson.py
+++ b/pyrff/test_thompson.py
@@ -39,3 +39,58 @@ class TestThompsonSampling:
         assert batch.count('C') != 0
         pass
 
+
+class TestThompsonProbabilities:
+    def test_sort_samples(self):
+        samples, sample_cols = thompson._sort_samples([
+            [3,1,2],
+            [4,-1],
+            [7],
+        ])
+        numpy.testing.assert_array_equal(samples, [-1, 1, 2, 3, 4, 7])
+        numpy.testing.assert_array_equal(sample_cols, [1, 0, 0, 0, 1, 2])
+        pass
+
+    def test_win_draw_prob(self):
+        assert thompson._win_draw_prob(numpy.array([
+            [1, 0, 0],
+            [0, 1, 1],
+            [0, 0, 0],
+        ])) == 0.0
+
+        assert thompson._win_draw_prob(numpy.array([
+            [0, 0, 0],
+            [0, 0, 0],
+            [1, 1, 1],
+        ])) == 0.25
+
+        numpy.testing.assert_allclose(thompson._win_draw_prob(numpy.array([
+            [0, 0],
+            [0.5, 0.75],
+            [0.5, 0.25],
+        ])), 0.041666666)
+        pass
+
+    def test_sampling_probability(self):
+        numpy.testing.assert_array_equal(thompson.sampling_probabilities([
+            [0, 1, 2],
+            [0, 1, 2],
+        ]), [0.5, 0.5])
+        
+        numpy.testing.assert_array_equal(thompson.sampling_probabilities([
+            [0, 1, 2],
+            [10],
+        ]), [0, 1])
+
+        numpy.testing.assert_array_equal(thompson.sampling_probabilities([
+            [0, 1, 2],
+            [3, 4, 5],
+            [5, 4, 3],
+        ]), [0, 0.5, 0.5])
+
+        numpy.testing.assert_array_equal(thompson.sampling_probabilities([
+            [5, 6],
+            [0, 0, 10, 20],
+            [5, 6],
+        ]), [0.25, 0.5, 0.25])
+        pass

--- a/pyrff/test_thompson.py
+++ b/pyrff/test_thompson.py
@@ -15,11 +15,11 @@ class TestThompsonSampling:
             low=[0, 0, -1],
             high=[0.2, 1, 0],
             size=(S, C)
-        )
-        numpy.testing.assert_array_equal(samples.shape, (S, C))
+        ).T
+        numpy.testing.assert_array_equal(samples.shape, (C, S))
 
         batch = thompson.sample_batch(
-            samples=samples, ids=ids,
+            candidate_samples=samples, ids=ids,
             batch_size=batch_size, seed=seed
         )
         assert len(batch) == batch_size
@@ -29,10 +29,11 @@ class TestThompsonSampling:
         pass
 
     def test_no_bias_on_sample_collisions(self):
-        samples = numpy.array([
+        samples = [
             [2, 2, 2],
+            [2, 2],
             [2, 2, 2],
-        ])
+        ]
         batch = thompson.sample_batch(samples, ids=('A', 'B', 'C'), batch_size=100, seed=1234)
         assert batch.count('A') != 100
         assert batch.count('C') != 0

--- a/pyrff/thompson.py
+++ b/pyrff/thompson.py
@@ -53,28 +53,3 @@ def sample_batch(
         chosen_candidates.append(best_candidate)
     random.seed(None)
     return tuple(chosen_candidates)
-
-
-def get_probabilities(samples:numpy.ndarray, nit:int=100_000):
-    """Get thompson sampling probabilities from posterior.
-
-    Parameters
-    ----------
-        samples : numpy.ndarray
-            (S, C) array of posterior samples (S) for each candidate (C)
-        nit : int
-            how many thompson draws samples to draw for the estimation
-
-    Returns
-    -------
-        probabilities : numpy.ndarray
-            (C,) probabilities that the candidates are sampled
-    """
-    n_samples, n_candidates = samples.shape
-
-    frequencies = numpy.zeros(n_candidates)
-    for _ in range(nit):
-        idx = numpy.random.randint(n_samples, size=n_candidates)
-        selected_samples = samples[idx, numpy.arange(n_candidates)]
-        frequencies[numpy.argmax(selected_samples)] += 1
-    return frequencies / frequencies.sum()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+fastprogress
 h5py
 numba
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 h5py
 numba
 numpy
+pandas
 pytest
 scipy
 typing

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 h5py
 numba
 numpy
-pandas
 pytest
 scipy
 typing


### PR DESCRIPTION
This PR changes the Thompson sampling API in the following ways:
+ signature of `sample_batch` changes:
  + samples must be passed as `(C, S)` or `(C, ?)` instead of `(S, C)`. This is to permit unequal sample sizes.
  + a new kwarg `correlated:bool` must be specified to choose between jointly or independently sampling from the candidate posterior samples
+ the brute-force function `get_probabilities` is replaced with `sampling_probabilities`.

The `sampling_probabilities` function takes `candidate_samples, correlated` in the same way as `sample_batch` to exactly calculate the Thompson sampling probability for each candidate by considering every possible outcome.