### PR TITLE
Remove typing package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ numba
 numpy
 pytest
 scipy
-typing


### PR DESCRIPTION
Typing causes problems on many recent python versions (3.7+). It should be removed.

https://github.com/python/typing/issues/573